### PR TITLE
Qt5 first porting - only installing & viewing installed packages works - Related to qmlpackagemanager

### DIFF
--- a/PackageKit-Qt/src/transaction.h
+++ b/PackageKit-Qt/src/transaction.h
@@ -1199,6 +1199,11 @@ public:
      */
     Q_INVOKABLE static QString packageIcon(const QString &packageID);
 
+    /**
+     * Returns the desktop files stored in the \p package.
+     */
+    static QStringList packageDesktopFiles(const QString &packageName);
+
 Q_SIGNALS:
     /**
      * The transaction has changed one of it's properties

--- a/PackageKit-Qt/src/transaction.h
+++ b/PackageKit-Qt/src/transaction.h
@@ -1177,27 +1177,27 @@ public:
     /**
      * Returns the package name from the \p packageID
      */
-    static QString packageName(const QString &packageID);
+    Q_INVOKABLE static QString packageName(const QString &packageID);
 
     /**
      * Returns the package version from the \p packageID
      */
-    static QString packageVersion(const QString &packageID);
+    Q_INVOKABLE static QString packageVersion(const QString &packageID);
 
     /**
      * Returns the package arch from the \p packageID
      */
-    static QString packageArch(const QString &packageID);
+    Q_INVOKABLE static QString packageArch(const QString &packageID);
 
     /**
      * Returns the package data from the \p packageID
      */
-    static QString packageData(const QString &packageID);
+    Q_INVOKABLE static QString packageData(const QString &packageID);
 
     /**
      * Returns the package icon from the \p packageID
      */
-    static QString packageIcon(const QString &packageID);
+    Q_INVOKABLE static QString packageIcon(const QString &packageID);
 
 Q_SIGNALS:
     /**

--- a/rpm/PackageKit-Qt.spec
+++ b/rpm/PackageKit-Qt.spec
@@ -1,6 +1,6 @@
 Summary:   Qt support library for PackageKit
 Name:      PackageKit-Qt
-Version:   0.8.8
+Version:   0.8.8-git29e4822
 Release:   1
 License:   GPLv2+
 Group:     System/Libraries

--- a/rpm/PackageKit-Qt.spec
+++ b/rpm/PackageKit-Qt.spec
@@ -1,6 +1,6 @@
 Summary:   Qt support library for PackageKit
 Name:      PackageKit-Qt
-Version:   0.8.8+nemo1
+Version:   0.8.8+nemo2
 Release:   1
 License:   GPLv2+
 Group:     System/Libraries

--- a/rpm/PackageKit-Qt.spec
+++ b/rpm/PackageKit-Qt.spec
@@ -1,6 +1,6 @@
 Summary:   Qt support library for PackageKit
 Name:      PackageKit-Qt
-Version:   0.8.8-git29e4822
+Version:   0.8.8+nemo1
 Release:   1
 License:   GPLv2+
 Group:     System/Libraries

--- a/rpm/PackageKit-Qt5.spec
+++ b/rpm/PackageKit-Qt5.spec
@@ -1,6 +1,6 @@
 Summary:   Qt support library for PackageKit
 Name:      PackageKit-Qt5
-Version:   0.8.8
+Version:   0.8.8-git29e4822
 Release:   1
 License:   GPLv2+
 Group:     System/Libraries

--- a/rpm/PackageKit-Qt5.spec
+++ b/rpm/PackageKit-Qt5.spec
@@ -1,7 +1,7 @@
 Summary:   Qt support library for PackageKit
 Name:      PackageKit-Qt5
-Version:   0.8.8.skytree4
-Release:   1%{?dist}
+Version:   0.8.8
+Release:   1
 License:   GPLv2+
 Group:     System/Libraries
 URL:       http://www.packagekit.org

--- a/rpm/PackageKit-Qt5.spec
+++ b/rpm/PackageKit-Qt5.spec
@@ -1,6 +1,6 @@
 Summary:   Qt support library for PackageKit
 Name:      PackageKit-Qt5
-Version:   0.8.8-git29e4822
+Version:   0.8.8+nemo1
 Release:   1
 License:   GPLv2+
 Group:     System/Libraries

--- a/rpm/PackageKit-Qt5.spec
+++ b/rpm/PackageKit-Qt5.spec
@@ -1,6 +1,6 @@
 Summary:   Qt support library for PackageKit
 Name:      PackageKit-Qt5
-Version:   0.8.8+nemo1
+Version:   0.8.8+nemo2
 Release:   1
 License:   GPLv2+
 Group:     System/Libraries

--- a/rpm/PackageKit-Qt5.spec
+++ b/rpm/PackageKit-Qt5.spec
@@ -1,11 +1,11 @@
 Summary:   Qt support library for PackageKit
 Name:      PackageKit-Qt5
-Version:   0.8.8
-Release:   1
+Version:   0.8.8.skytree4
+Release:   1%{?dist}
 License:   GPLv2+
 Group:     System/Libraries
 URL:       http://www.packagekit.org
-Source0:   http://www.packagekit.org/releases/%{name}-%{version}.tar.xz
+Source0:   %{name}-%{version}.tar.xz
 
 Requires: PackageKit >= 0.8.9
 BuildRequires: pkgconfig(Qt5Core)


### PR DESCRIPTION
qmlpackagemanager first Qt5 porting  https://github.com/nemomobile/qmlpackagemanager/pull/2
 may require few functions to Q_INVOKABLE
 This PR have these changes, please read https://github.com/nemomobile/qmlpackagemanager/pull/2 about it
if you don't need those functions to be Q_INVOKABLE, you can ignore all this.
